### PR TITLE
Update node

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - uses: actions/checkout@v2
       - run: yarn install --frozen-lockfile
       - run: npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: the-iea/skip-duplicate-actions@master
+        uses: the-iea/skip-duplicate-actions@update-node
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
           concurrent_skipping: 'never'
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: skip_check
-        uses: the-iea/skip-duplicate-actions@master
+        uses: the-iea/skip-duplicate-actions@update-node
         with:
           cancel_others: 'false'
           paths: '["src/**", "dist/**"]'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,7 +12,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: the-iea/skip-duplicate-actions@update-node
+        uses: the-iea/skip-duplicate-actions@master
         with:
           # All of these options are optional, so you can remove them if you are happy with the defaults
           concurrent_skipping: 'never'
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - id: skip_check
-        uses: the-iea/skip-duplicate-actions@update-node
+        uses: the-iea/skip-duplicate-actions@master
         with:
           cancel_others: 'false'
           paths: '["src/**", "dist/**"]'

--- a/action.yml
+++ b/action.yml
@@ -40,5 +40,5 @@ outputs:
   superceder:
     description: 'an object containing context of the run that supercedes this one'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
fixed the actions https://github.com/the-iea/skip-duplicate-actions/actions/runs/5927006641 is updated and using node version 16. so basically this is a custom action that has its own repo in the IEA. And the way i tested the workflow is by pointing the action to pick up the changes from my new branch update-node where i bumped node from 12 to 16. 
Run actions/setup-node@v1  /opt/hostedtoolcache/node/16.20.2/x64/bin/node --version v16.20.2  - build.yml - tests the build run of the workflow
the-iea/skip-duplicate-actions@update-node   - gets config from action.yml where node version is updated runs: using: 'node16' main: 'dist/index.js' 

https://github.com/the-iea/skip-duplicate-actions/actions/runs/5926958667 - test.yml - passed
https://github.com/the-iea/skip-duplicate-actions/actions/runs/5927006638 - build.yml - passed 

Final PR https://github.com/the-iea/skip-duplicate-actions/pull/35 - reverting back the branch once version test is complete. (tests have passed) if merged to master, any other workflow using this action is able to pull direclty from master with node version 16